### PR TITLE
feat: add details to `about` command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,11 +16,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.1]
-        laravel: [9.*]
+        laravel: ['^9.22']
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 9.*
-            testbench: ^7.0
+          - laravel: '^9.22'
+            testbench: '^7.0'
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
     "require": {
         "php": "^8.1",
         "guzzlehttp/guzzle": "^7.5",
-        "illuminate/contracts": "^9.0",
+        "laravel/framework": "^9.22",
         "pragmarx/google2fa": "^8.0",
         "spatie/laravel-package-tools": "^1.12.1"
     },
     "require-dev": {
         "nunomaduro/collision": "^6.3",
         "nunomaduro/larastan": "^2.0",
-        "orchestra/testbench": "^7.7",
+        "orchestra/testbench": "^7.8",
         "pestphp/pest": "^1.22",
         "pestphp/pest-plugin-parallel": "^1.2",
         "pestphp/pest-plugin-laravel": "^1.1",

--- a/config/mfa.php
+++ b/config/mfa.php
@@ -48,4 +48,15 @@ return [
 
     ],
 
+    'features' => [
+
+        /**
+         * Laravel's about command provides useful information regarding the state of
+         * your Laravel application. If `about_command` is set to true, we will
+         * show useful information about exchange in about command output.
+         */
+        'about_command' => true,
+
+    ]
+
 ];

--- a/src/Enums/Channel.php
+++ b/src/Enums/Channel.php
@@ -9,4 +9,14 @@ enum Channel: string
     case Email = 'email';
     case Sms = 'sms';
     case Totp = 'totp';
+
+    public static function driverDescription(string $channel): string
+    {
+        return match (self::tryFrom($channel)) {
+            self::Email => 'Email Driver',
+            self::Sms => 'SMS Driver',
+            self::Totp => 'TOTP Driver',
+            default => 'Unknown Driver',
+        };
+    }
 }

--- a/src/MultiFactorAuthServiceProvider.php
+++ b/src/MultiFactorAuthServiceProvider.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Worksome\MultiFactorAuth;
 
+use Illuminate\Foundation\Console\AboutCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Worksome\MultiFactorAuth\Enums\Channel;
 
 class MultiFactorAuthServiceProvider extends PackageServiceProvider
 {
@@ -20,5 +22,31 @@ class MultiFactorAuthServiceProvider extends PackageServiceProvider
             ->name('laravel-mfa')
             ->hasConfigFile()
             ->hasMigration('create_mfa_multi_factors_table');
+    }
+
+    public function bootingPackage(): void
+    {
+        $this->extendAboutCommand();
+    }
+
+    private function extendAboutCommand(): void
+    {
+        if (! config('mfa.features.about_command', true)) {
+            return;
+        }
+
+        /** @var array<class-string<Channel>, array{driver: string|null}> $channels */
+        $channels = config('mfa.channels', []);
+
+        if (empty($channels)) {
+            return;
+        }
+
+        AboutCommand::add(
+            'Multi-Factor Authentication (MFA)',
+            fn () => collect($channels)->mapWithKeys(fn (array $config, string $channel) => [
+                Channel::driverDescription($channel) => $config['driver'] ?? 'null'
+            ])
+        );
     }
 }

--- a/tests/Feature/Commands/AboutCommandTest.php
+++ b/tests/Feature/Commands/AboutCommandTest.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+it('shows MFA details', function () {
+    $this->artisan('about')
+        ->assertSuccessful()
+        ->expectsOutputToContain('Multi-Factor Authentication (MFA)')
+        ->expectsOutputToContain('Email Driver')
+        ->expectsOutputToContain('SMS Driver')
+        ->expectsOutputToContain('TOTP Driver');
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ namespace Worksome\MultiFactorAuth\Tests;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Orchestra\Testbench\TestCase as Orchestra;
+use Worksome\MultiFactorAuth\Enums\Channel;
 use Worksome\MultiFactorAuth\MultiFactorAuthServiceProvider;
 
 class TestCase extends Orchestra
@@ -22,14 +23,14 @@ class TestCase extends Orchestra
         );
     }
 
-    protected function getPackageProviders($app)
+    protected function getPackageProviders($app): array
     {
         return [
             MultiFactorAuthServiceProvider::class,
         ];
     }
 
-    public function getEnvironmentSetUp($app)
+    public function defineEnvironment($app)
     {
         config()->set('database.default', 'testing');
     }


### PR DESCRIPTION
Basically the equivalent to https://github.com/worksome/exchange/pull/9 👍🏻

![Screenshot 2022-10-03 at 17 12 44](https://user-images.githubusercontent.com/1899334/193626793-8fe71e15-acc6-4076-99a9-4f6b84c39f25.png)

The feature can be disabled by setting the `mfa.features.about_command` config variable to false. It is also automatically disabled in Laravel versions prior to the introduction of the `AboutCommand`.

As with the other one, I'm not sure whether to make it opt-in or opt-out. 🤔