### PR TITLE
feat!: update `Status` enum casing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Worksome\\MultiFactorAuth\\": "src",
-            "Worksome\\MultiFactorAuth\\Database\\Factories\\": "database/factories"
+            "Worksome\\MultiFactorAuth\\": "src"
         }
     },
     "autoload-dev": {

--- a/src/Drivers/Email/NullEmailDriver.php
+++ b/src/Drivers/Email/NullEmailDriver.php
@@ -16,7 +16,7 @@ class NullEmailDriver extends AbstractEmailDriver
 
     public function make(Identifier $to): CreationResponse
     {
-        return new CreationResponse($this->status ?? Status::PENDING);
+        return new CreationResponse($this->status ?? Status::Pending);
     }
 
     public function verify(Identifier $to, string $code): bool

--- a/src/Drivers/Email/TwilioVerifyEmailDriver.php
+++ b/src/Drivers/Email/TwilioVerifyEmailDriver.php
@@ -35,6 +35,6 @@ class TwilioVerifyEmailDriver extends AbstractEmailDriver
 
         assert(isset($data['status']));
 
-        return Status::fromTwilioVerify($data['status']) === Status::APPROVED;
+        return Status::fromTwilioVerify($data['status']) === Status::Approved;
     }
 }

--- a/src/Drivers/Sms/NullSmsDriver.php
+++ b/src/Drivers/Sms/NullSmsDriver.php
@@ -16,7 +16,7 @@ class NullSmsDriver extends AbstractSmsDriver
 
     public function make(Identifier $to): CreationResponse
     {
-        return new CreationResponse($this->status ?? Status::PENDING);
+        return new CreationResponse($this->status ?? Status::Pending);
     }
 
     public function verify(Identifier $to, string $code): bool

--- a/src/Drivers/Sms/TwilioVerifySmsDriver.php
+++ b/src/Drivers/Sms/TwilioVerifySmsDriver.php
@@ -35,6 +35,6 @@ class TwilioVerifySmsDriver extends AbstractSmsDriver
 
         assert(isset($data['status']));
 
-        return Status::fromTwilioVerify($data['status']) === Status::APPROVED;
+        return Status::fromTwilioVerify($data['status']) === Status::Approved;
     }
 }

--- a/src/Drivers/Totp/BasicTotpDriver.php
+++ b/src/Drivers/Totp/BasicTotpDriver.php
@@ -19,7 +19,7 @@ class BasicTotpDriver extends AbstractTotpDriver
 
     public function make(Identifier $to): CreationResponse
     {
-        return new CreationResponse(Status::PENDING);
+        return new CreationResponse(Status::Pending);
     }
 
     public function verify(Identifier $to, string $code): bool

--- a/src/Drivers/Totp/NullTotpDriver.php
+++ b/src/Drivers/Totp/NullTotpDriver.php
@@ -20,7 +20,7 @@ class NullTotpDriver extends AbstractSmsDriver
 
     public function make(Identifier $to): CreationResponse
     {
-        return new CreationResponse($this->status ?? Status::PENDING, [
+        return new CreationResponse($this->status ?? Status::Pending, [
             'secret' => 'TEST',
         ]);
     }

--- a/src/Enums/Status.php
+++ b/src/Enums/Status.php
@@ -6,18 +6,18 @@ namespace Worksome\MultiFactorAuth\Enums;
 
 enum Status: string
 {
-    case APPROVED = 'approved';
-    case PENDING = 'pending';
-    case CANCELLED = 'cancelled';
-    case FAILED = 'failed';
+    case Approved = 'approved';
+    case Pending = 'pending';
+    case Cancelled = 'cancelled';
+    case Failed = 'failed';
 
     public static function fromTwilioVerify(string $status): self
     {
         return match ($status) {
-            'approved' => self::APPROVED,
-            'pending', 'unverified' => self::PENDING,
-            'canceled' => self::CANCELLED,
-            default => self::FAILED,
+            'approved' => self::Approved,
+            'pending', 'unverified' => self::Pending,
+            'canceled' => self::Cancelled,
+            default => self::Failed,
         };
     }
 }

--- a/tests/Feature/Casts/ToFieldCasterTest.php
+++ b/tests/Feature/Casts/ToFieldCasterTest.php
@@ -15,7 +15,7 @@ it('can cast from cents to a number', function (Channel $channel, E164PhoneNumbe
         'channel' => $channel,
         'to' => $to,
         'user_id' => 1,
-        'status' => Status::PENDING,
+        'status' => Status::Pending,
     ])->refresh();
 
     expect($factor->channel)->toEqual($channel)

--- a/tests/Feature/Drivers/Email/NullDriverTest.php
+++ b/tests/Feature/Drivers/Email/NullDriverTest.php
@@ -9,7 +9,7 @@ use Worksome\MultiFactorAuth\Enums\Status;
 
 it('can send Email from the Null driver', function () {
     $driver = (new NullEmailDriver())
-        ->fakeStatus(Status::PENDING)
+        ->fakeStatus(Status::Pending)
         ->fakeVerified();
 
     $status = $driver->make(
@@ -17,12 +17,12 @@ it('can send Email from the Null driver', function () {
     );
 
     expect($status)->toBeInstanceOf(CreationResponse::class)
-        ->status->toBe(Status::PENDING);
+        ->status->toBe(Status::Pending);
 });
 
 it('can verify Email from the Null driver', function () {
     $driver = (new NullEmailDriver())
-        ->fakeStatus(Status::PENDING)
+        ->fakeStatus(Status::Pending)
         ->fakeVerified(false);
 
     $emailAddress = new EmailAddress('test@example.org');
@@ -32,7 +32,7 @@ it('can verify Email from the Null driver', function () {
     )->toBeFalse();
 
     $driver
-        ->fakeStatus(Status::APPROVED)
+        ->fakeStatus(Status::Approved)
         ->fakeVerified();
 
     expect(

--- a/tests/Feature/Drivers/Email/TwilioVerifyDriverTest.php
+++ b/tests/Feature/Drivers/Email/TwilioVerifyDriverTest.php
@@ -31,12 +31,12 @@ it('can retrieve an Email Verification response from the Twilio Verify driver', 
     $status = $driver->make(new EmailAddress('test@example.org'));
 
     expect($status)->toBeInstanceOf(CreationResponse::class)
-        ->status->toBe(Status::PENDING)
+        ->status->toBe(Status::Pending)
         ->data->toBeArray()
         ->data->to->toBe('test@example.org')
         ->data->channel->toBe(Channel::Email->value)
         ->data->sid->toBe('VEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
-        ->data->status->toBe(Status::PENDING->value);
+        ->data->status->toBe(Status::Pending->value);
 });
 
 it('can retrieve an Email Verification Check response from the Twilio Verify driver', function () {

--- a/tests/Feature/Drivers/Sms/NullDriverTest.php
+++ b/tests/Feature/Drivers/Sms/NullDriverTest.php
@@ -9,7 +9,7 @@ use Worksome\MultiFactorAuth\Enums\Status;
 
 it('can send SMS from the Null driver', function () {
     $driver = (new NullSmsDriver())
-        ->fakeStatus(Status::PENDING)
+        ->fakeStatus(Status::Pending)
         ->fakeVerified();
 
     $status = $driver->make(
@@ -17,12 +17,12 @@ it('can send SMS from the Null driver', function () {
     );
 
     expect($status)->toBeInstanceOf(CreationResponse::class)
-        ->status->toBe(Status::PENDING);
+        ->status->toBe(Status::Pending);
 });
 
 it('can verify SMS from the Null driver', function () {
     $driver = (new NullSmsDriver())
-        ->fakeStatus(Status::PENDING)
+        ->fakeStatus(Status::Pending)
         ->fakeVerified(false);
 
     $phoneNumber = new E164PhoneNumber('+14155552671');
@@ -32,7 +32,7 @@ it('can verify SMS from the Null driver', function () {
     )->toBeFalse();
 
     $driver
-        ->fakeStatus(Status::APPROVED)
+        ->fakeStatus(Status::Approved)
         ->fakeVerified();
 
     expect(

--- a/tests/Feature/Drivers/Sms/TwilioVerifyDriverTest.php
+++ b/tests/Feature/Drivers/Sms/TwilioVerifyDriverTest.php
@@ -31,12 +31,12 @@ it('can retrieve an SMS Verification response from the Twilio Verify driver', fu
     $status = $driver->make(new E164PhoneNumber('+15017122661'));
 
     expect($status)->toBeInstanceOf(CreationResponse::class)
-        ->status->toBe(Status::PENDING)
+        ->status->toBe(Status::Pending)
         ->data->toBeArray()
         ->data->to->toBe('+15017122661')
         ->data->channel->toBe(Channel::Sms->value)
         ->data->sid->toBe('VEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
-        ->data->status->toBe(Status::PENDING->value);
+        ->data->status->toBe(Status::Pending->value);
 });
 
 it('can retrieve an SMS Verification Check response from the Twilio Verify driver', function () {

--- a/tests/Feature/Drivers/Totp/NullDriverTest.php
+++ b/tests/Feature/Drivers/Totp/NullDriverTest.php
@@ -9,7 +9,7 @@ use Worksome\MultiFactorAuth\Enums\Status;
 
 it('can make TOTP from the Null driver', function () {
     $driver = (new NullTotpDriver())
-        ->fakeStatus(Status::PENDING)
+        ->fakeStatus(Status::Pending)
         ->fakeVerified();
 
     $status = $driver->make(
@@ -17,12 +17,12 @@ it('can make TOTP from the Null driver', function () {
     );
 
     expect($status)->toBeInstanceOf(CreationResponse::class)
-        ->status->toBe(Status::PENDING);
+        ->status->toBe(Status::Pending);
 });
 
 it('can verify TOTP from the Null driver', function () {
     $driver = (new NullTotpDriver())
-        ->fakeStatus(Status::PENDING)
+        ->fakeStatus(Status::Pending)
         ->fakeVerified(false);
 
     $secret = new TotpSecret('TESTSECRET');
@@ -32,7 +32,7 @@ it('can verify TOTP from the Null driver', function () {
     )->toBeFalse();
 
     $driver
-        ->fakeStatus(Status::APPROVED)
+        ->fakeStatus(Status::Approved)
         ->fakeVerified();
 
     expect(

--- a/tests/Feature/Facades/MultiFactorAuthFacadeTest.php
+++ b/tests/Feature/Facades/MultiFactorAuthFacadeTest.php
@@ -20,7 +20,7 @@ it('can create an SMS driver from the facade', function () {
 
     expect($response)
         ->toBeInstanceOf(CreationResponse::class)
-        ->status->toBe(Status::PENDING);
+        ->status->toBe(Status::Pending);
 });
 
 it('can create an email driver from the facade', function () {
@@ -30,7 +30,7 @@ it('can create an email driver from the facade', function () {
 
     expect($response)
         ->toBeInstanceOf(CreationResponse::class)
-        ->status->toBe(Status::PENDING);
+        ->status->toBe(Status::Pending);
 });
 
 it('can create a TOTP driver from the facade', function () {
@@ -40,5 +40,5 @@ it('can create a TOTP driver from the facade', function () {
 
     expect($response)
         ->toBeInstanceOf(CreationResponse::class)
-        ->status->toBe(Status::PENDING);
+        ->status->toBe(Status::Pending);
 });

--- a/tests/Unit/DataValues/TwilioVerify/CreationResponseTest.php
+++ b/tests/Unit/DataValues/TwilioVerify/CreationResponseTest.php
@@ -11,6 +11,6 @@ it('can create a valid creation response', function (Status $status, array $data
         ->status->toBe($status)
         ->data->toBe($data);
 })->with([
-    'status' => [Status::APPROVED, []],
-    'status and data' => [Status::APPROVED, ['valid' => true]],
+    'status' => [Status::Approved, []],
+    'status and data' => [Status::Approved, ['valid' => true]],
 ]);

--- a/tests/Unit/Services/TwilioVerify/ClientTest.php
+++ b/tests/Unit/Services/TwilioVerify/ClientTest.php
@@ -54,7 +54,7 @@ it('can retrieve an SMS response from the Twilio Verify API check', function () 
         ->sid->toBe('VEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
         ->to->toBe('+15017122661')
         ->channel->toBe(Channel::Sms->value)
-        ->status->toBe(Status::APPROVED->value);
+        ->status->toBe(Status::Approved->value);
 });
 
 it('can retrieve an Email response from the Twilio Verify API', function () {
@@ -103,7 +103,7 @@ it('can retrieve an Email response from the Twilio Verify API check', function (
         ->sid->toBe('VEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
         ->to->toBe('test@example.org')
         ->channel->toBe(Channel::Email->value)
-        ->status->toBe(Status::APPROVED->value);
+        ->status->toBe(Status::Approved->value);
 });
 
 it('throws an exception when no service id is provided', function () {


### PR DESCRIPTION
This updates the case of our `Status` enum cases from screaming snake case to pascal case.

> [!Warning]
> **This is a breaking change.**
> 
> - `Status::APPROVED` => `Status::Approved`
> - `Status::PENDING` => `Status::Pending`
> - `Status::CANCELLED` => `Status::Cancelled`
> - `Status::FAILED` => `Status::Failed`